### PR TITLE
setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 /target
 /Cargo.lock
+/cargo/*/Cargo.toml
+/cargo/*/Cargo.lock
+/*.profraw
 .idea

--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,1 @@
+use_small_heuristics = "Max"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,4 +8,5 @@ license = "Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+# cesride = { version = "0.1.3", path = "../cesride" }
 cesride = "0.1.3"

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,30 @@
+python:
+	@cp Cargo.toml cargo/$@/
+	@echo "pyo3 = { version = \"0.18.0\", features = [\"abi3\", \"extension-module\"] }" >> cargo/$@/Cargo.toml
+	@echo >> cargo/$@/Cargo.toml
+	@cat cargo/$@/Cargo.toml.tail >> cargo/$@/Cargo.toml
+	@cd cargo/$@ && cargo build --release --target-dir ../../target/$@
+	@mv target/$@/release/libparside.dylib target/$@/release/parside.so
+
+python-shell:
+	@cd target/python/release/ && python3
+
+rust:
+	@cargo build --release
+
+libs: rust python
+
+clean:
+	cargo clean
+
+fix:
+	cargo fix
+	cargo fmt
+
+preflight:
+	cargo fmt --check
+	cargo clippy -- -D warnings
+	cargo build --release
+	cargo test --release
+	cargo audit
+	cargo tarpaulin

--- a/cargo/python/.cargo/config.toml
+++ b/cargo/python/.cargo/config.toml
@@ -1,0 +1,11 @@
+[target.x86_64-apple-darwin]
+rustflags = [
+  "-C", "link-arg=-undefined",
+  "-C", "link-arg=dynamic_lookup",
+]
+
+[target.aarch64-apple-darwin]
+rustflags = [
+  "-C", "link-arg=-undefined",
+  "-C", "link-arg=dynamic_lookup",
+]

--- a/cargo/python/Cargo.toml.tail
+++ b/cargo/python/Cargo.toml.tail
@@ -1,0 +1,11 @@
+[lib]
+path = "../../src/lib_python.rs"
+test = false
+doctest = false
+bench = true
+doc = true
+crate-type = ["cdylib"]
+
+[features]
+default = ["python"]
+python = []

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,10 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 95
+        paths: ["src"]
+    patch:
+      default:
+        target: 75
+        paths: ["src"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,14 +1,1 @@
-pub fn add(left: usize, right: usize) -> usize {
-    left + right
-}
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
-    }
-}

--- a/src/lib_python.rs
+++ b/src/lib_python.rs
@@ -1,0 +1,14 @@
+// TODO: remove before 1.0.0
+#![allow(dead_code)]
+
+use pyo3::prelude::*;
+
+// mod core;
+// mod error;
+// mod python;
+
+#[pymodule]
+fn parside(_py: Python, m: &PyModule) -> PyResult<()> {
+    // m.add_class::<Matter>()?;
+    Ok(())
+}


### PR DESCRIPTION
## Rationale

We want the same things happening here as we have in `cesride`.

## Changes

- Better formatting
- `.gitgnore` generated files
- `Makefile` for convenience
- Codecov targets
- Commented line for `cesride` local dev in `Cargo.toml`
- Python integration

## Testing
```
> make clean preflight libs python-shell
# ...
Python 3.10.6 (main, Aug 11 2022, 13:49:25) [Clang 13.1.6 (clang-1316.0.21.2.5)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import parside
>>> 
```