### PR TITLE
update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "parside"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 description = "Parser for Composable Event Streaming Representation (CESR)"
 license = "Apache-2.0"
 
 [dependencies]
-cesride = "0.6.0"
+cesride = "0.6.4"
 nom = "~7.1"
 num-derive = "~0.3"
 num-traits = "~0.2"


### PR DESCRIPTION
bumps `cesride` version.